### PR TITLE
Multiple deploy changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A disaster readiness website specific to the Seattle metro area.
 
 The project is a custom instance of the [Disaster Preparedness](https://github.com/missoula-ready/disaster-preparedness) project, which is an adaptation of [a pioneering project from Oregon](https://github.com/Oregon-Public-Broadcasting/earthquake-preparedness) but has been generalized to make it easy to clone and tailor to other regions.
 
-# To set it up, follow the instructions in the [Disaster Preparedness project README](https://github.com/missoula-ready/disaster-preparedness/blob/master/README.md).
+# To set it up, follow the instructions in the [Disaster Preparedness project README](https://github.com/missoula-ready/disaster-preparedness/blob/master/README.md). But instead of DJANGO_SECRET_KEY, use DJANGO_SECRET_KEY_SEATTLE, and instead of DATABASE_URL, use DATABASE_URL_SEATTLE.
 
 # Values to put in Django Admin
 

--- a/disasterinfosite/settings.py
+++ b/disasterinfosite/settings.py
@@ -12,7 +12,7 @@ from os import environ
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
+SECRET_KEY = os.environ['DJANGO_SECRET_KEY_SEATTLE']
 
 
 # SECURITY WARNING: don't run with debug turned on in production!
@@ -81,7 +81,7 @@ TEMPLATE_LOADERS = (
 import dj_database_url
 
 DATABASES = {}
-DATABASES['default'] =  dj_database_url.config()
+DATABASES['default'] =  dj_database_url.parse(os.environ["DATABASE_URL_SEATTLE"])
 DATABASES['default']['ENGINE'] = 'django.contrib.gis.db.backends.postgis'
 
 # Allow database connections to persist


### PR DESCRIPTION
While setting up a demo server spot for Seattle Ready, I realized that the environment variables on there will clash with the ones for Missoula Ready, so I changed their names in the settings for this app.