### PR TITLE
Make fonts a little more Seattle-y

### DIFF
--- a/disasterinfosite/static/css/app.css
+++ b/disasterinfosite/static/css/app.css
@@ -10,14 +10,14 @@ html {
 body {
   height:auto !important;
   width:auto !important;
-  font-family: Georgia, Times, 'Times New Roman', serif;
+  font-family: 'Arvo', serif;
   color: #444;
 }
 
 /*****
 TYPOGRAPHY STYLES
 ******/
-.sans-serif {  font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif; }
+.sans-serif {  font-family: 'Open Sans', sans-serif; }
 .vert-pad-medium { padding: 2em 0; }
 .caps {
   text-transform: uppercase;

--- a/disasterinfosite/templates/index.html
+++ b/disasterinfosite/templates/index.html
@@ -27,6 +27,10 @@
 <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/jquery.slick/1.5.9/slick.css"/>
 <script type="text/javascript" src="//cdn.jsdelivr.net/jquery.slick/1.5.9/slick.min.js"></script>
 
+<!-- Load fonts -->
+<link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css?family=Arvo" rel="stylesheet">
+
 <script type="text/javascript">
   var mapBounds = {{ data_bounds | js }};
 </script>


### PR DESCRIPTION
Sans-serif fonts are now Open Sans, which is used by the Seattle and King County websites.

Serif fonts are Arvo, which I thought went well with Open Sans and has a clean, modern look.

![fireshot capture 3 - king county ready - http___localhost_8000_](https://cloud.githubusercontent.com/assets/547883/19094929/cc6d7ae6-8a47-11e6-984f-d1ea01c52e79.png)
