### PR TITLE
Create an empty profile for the user if one doesn't exist

### DIFF
--- a/disasterinfosite/views.py
+++ b/disasterinfosite/views.py
@@ -93,7 +93,7 @@ def app_view(request):
     profile = None
     if request.user.is_authenticated():
         username = request.user.username
-        profile = UserProfile.objects.get(user=request.user)
+        profile = UserProfile.objects.get_or_create(user=request.user)
 
     template = "no_content_found.html"
 


### PR DESCRIPTION
This is to fix that bug where the command-line created superuser doesn't have a profile and makes the site crash when you visit it while logged in as that person because you logged in through Django Admin.

Once this is in I'll port it to the other 2 repos because it's really annoying.