### PR TITLE
Fix iphone specific layout bug

### DIFF
--- a/disasterinfosite/static/css/app.css
+++ b/disasterinfosite/static/css/app.css
@@ -686,7 +686,7 @@ GEEK BOX
 
   .past-photos {
     width: 272px;
-    height: 200px;
+    height: 250px;
   }
 
   .slideshow-image {


### PR DESCRIPTION
Photos were running over the end of the div on small sizes.