### PR TITLE
Even up spacing on active disaster tab

### DIFF
--- a/disasterinfosite/static/css/app.css
+++ b/disasterinfosite/static/css/app.css
@@ -284,11 +284,8 @@ DISASTER TABS
 }
 
 .tabs-content > .content.active {
-  display: inline-block;
-  float: right;
   margin-top: 10px;
   padding: 1rem;
-  width: 98%;
 }
 
 .tabs dd.active a, .tabs .tab-title.active a {


### PR DESCRIPTION
This fix should be backported to both missoula-ready and disaster-preparedness.