### PR TITLE
Match the usual order of snugget sections with the homepage sections

### DIFF
--- a/disasterinfosite/templates/index.html
+++ b/disasterinfosite/templates/index.html
@@ -95,11 +95,11 @@
         <h3 class>What to Expect</h3>
         <p>{{ settings.site_title }} gives you an idea of which natural disasters you might experience in the future based on a location in {{ location.area_name }}.</p>
 
-        <h3>In Recent History</h3>
-        <p>Find out which disasters have struck {{ location.area_name }} in the past, what impact they had, and where they happened.</p>
-
         <h3>How to Prepare</h3>
         <p>You have the power to make a difference. Find out how you can protect your loved ones and home before the next disaster hits.</p>
+
+        <h3>In Recent History</h3>
+        <p>Find out which disasters have struck {{ location.area_name }} in the past, what impact they had, and where they happened.</p>
       </div>
       </div>
 {% endblock map %}


### PR DESCRIPTION
This should be backported to both missoula-ready and disaster-preparedness.