### PR TITLE
Enable translation of snuggets and snugget sections/subsections

### DIFF
--- a/disasterinfosite/admin.py
+++ b/disasterinfosite/admin.py
@@ -14,8 +14,8 @@ from .models import EmbedSnugget, TextSnugget, SnuggetSection, SnuggetSubSection
 from .models import ShapefileGroup, PastEventsPhoto, DataOverviewImage, UserProfile
 from .actions import export_as_csv_action
 
-admin.site.register(SnuggetSection, admin.ModelAdmin)
-admin.site.register(SnuggetSubSection, admin.ModelAdmin)
+admin.site.register(SnuggetSection, TranslationAdmin)
+admin.site.register(SnuggetSubSection, TranslationAdmin)
 admin.site.register(ShapefileGroup, TranslationAdmin)
 admin.site.register(PastEventsPhoto, TranslationAdmin)
 admin.site.register(DataOverviewImage, TranslationAdmin)
@@ -45,7 +45,7 @@ class SnuggetAdmin(admin.ModelAdmin):
         return "Undefined"
 
 
-class TextAdmin(SnuggetAdmin):
+class TextAdmin(SnuggetAdmin, TranslationAdmin):
     fieldsets = SnuggetAdmin.fieldsets + ((None, {
         'fields': ('content',),
         }),

--- a/disasterinfosite/migrations/0004_model-translation.py
+++ b/disasterinfosite/migrations/0004_model-translation.py
@@ -139,7 +139,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='snuggetsection',
-            name='display_name_en_us',
+            name='display_name_en',
             field=models.CharField(blank=True, help_text='The name to show for this section', max_length=50, null=True),
         ),
         migrations.AddField(
@@ -150,21 +150,21 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='snuggetsubsection',
             name='display_name',
-            field=models.CharField(blank=True, default='The name to show for this section', max_length=50),
+            field=models.CharField(blank=True, help_text='The name to show for this section', max_length=50),
         ),
         migrations.AddField(
             model_name='snuggetsubsection',
-            name='display_name_en_us',
-            field=models.CharField(blank=True, default='The name to show for this section', max_length=50, null=True),
+            name='display_name_en',
+            field=models.CharField(blank=True, help_text='The name to show for this section', max_length=50, null=True),
         ),
         migrations.AddField(
             model_name='snuggetsubsection',
             name='display_name_es',
-            field=models.CharField(blank=True, default='The name to show for this section', max_length=50, null=True),
+            field=models.CharField(blank=True, help_text='The name to show for this section', max_length=50, null=True),
         ),
         migrations.AddField(
             model_name='textsnugget',
-            name='content_en_us',
+            name='content_en',
             field=models.TextField(null=True),
         ),
         migrations.AddField(

--- a/disasterinfosite/migrations/0004_model-translation.py
+++ b/disasterinfosite/migrations/0004_model-translation.py
@@ -112,15 +112,20 @@ class Migration(migrations.Migration):
             name='caption_es',
             field=models.TextField(default='', max_length=500, null=True),
         ),
+        migrations.AlterField(
+            model_name='shapefilegroup',
+            name='display_name',
+            field=models.CharField(max_length=50, default=''),
+        ),
         migrations.AddField(
             model_name='shapefilegroup',
             name='display_name_en',
-            field=models.CharField(max_length=50, null=True),
+            field=models.CharField(max_length=50, null=True, default=''),
         ),
         migrations.AddField(
             model_name='shapefilegroup',
             name='display_name_es',
-            field=models.CharField(max_length=50, null=True),
+            field=models.CharField(max_length=50, null=True, default=''),
         ),
         migrations.AddField(
             model_name='supplykit',
@@ -135,32 +140,32 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='snuggetsection',
             name='display_name',
-            field=models.CharField(blank=True, help_text='The name to show for this section', max_length=50),
+            field=models.CharField(help_text='The name to show for this section', max_length=50, default=""),
         ),
         migrations.AddField(
             model_name='snuggetsection',
             name='display_name_en',
-            field=models.CharField(blank=True, help_text='The name to show for this section', max_length=50, null=True),
+            field=models.CharField(help_text='The name to show for this section', max_length=50, null=True, default=''),
         ),
         migrations.AddField(
             model_name='snuggetsection',
             name='display_name_es',
-            field=models.CharField(blank=True, help_text='The name to show for this section', max_length=50, null=True),
+            field=models.CharField(help_text='The name to show for this section', max_length=50, null=True, default=''),
         ),
         migrations.AddField(
             model_name='snuggetsubsection',
             name='display_name',
-            field=models.CharField(blank=True, help_text='The name to show for this section', max_length=50),
+            field=models.CharField(help_text='The name to show for this section', max_length=50, default=''),
         ),
         migrations.AddField(
             model_name='snuggetsubsection',
             name='display_name_en',
-            field=models.CharField(blank=True, help_text='The name to show for this section', max_length=50, null=True),
+            field=models.CharField(help_text='The name to show for this section', max_length=50, null=True, default=''),
         ),
         migrations.AddField(
             model_name='snuggetsubsection',
             name='display_name_es',
-            field=models.CharField(blank=True, help_text='The name to show for this section', max_length=50, null=True),
+            field=models.CharField(help_text='The name to show for this section', max_length=50, null=True, default=''),
         ),
         migrations.AddField(
             model_name='textsnugget',

--- a/disasterinfosite/migrations/0004_model-translation.py
+++ b/disasterinfosite/migrations/0004_model-translation.py
@@ -132,4 +132,44 @@ class Migration(migrations.Migration):
             name='text_es',
             field=models.TextField(help_text='More information about building your supply kit. Any web address in here gets turned into a link automatically.', null=True),
         ),
+        migrations.AddField(
+            model_name='snuggetsection',
+            name='display_name',
+            field=models.CharField(blank=True, help_text='The name to show for this section', max_length=50),
+        ),
+        migrations.AddField(
+            model_name='snuggetsection',
+            name='display_name_en_us',
+            field=models.CharField(blank=True, help_text='The name to show for this section', max_length=50, null=True),
+        ),
+        migrations.AddField(
+            model_name='snuggetsection',
+            name='display_name_es',
+            field=models.CharField(blank=True, help_text='The name to show for this section', max_length=50, null=True),
+        ),
+        migrations.AddField(
+            model_name='snuggetsubsection',
+            name='display_name',
+            field=models.CharField(blank=True, default='The name to show for this section', max_length=50),
+        ),
+        migrations.AddField(
+            model_name='snuggetsubsection',
+            name='display_name_en_us',
+            field=models.CharField(blank=True, default='The name to show for this section', max_length=50, null=True),
+        ),
+        migrations.AddField(
+            model_name='snuggetsubsection',
+            name='display_name_es',
+            field=models.CharField(blank=True, default='The name to show for this section', max_length=50, null=True),
+        ),
+        migrations.AddField(
+            model_name='textsnugget',
+            name='content_en_us',
+            field=models.TextField(null=True),
+        ),
+        migrations.AddField(
+            model_name='textsnugget',
+            name='content_es',
+            field=models.TextField(null=True),
+        ),
     ]

--- a/disasterinfosite/models.py
+++ b/disasterinfosite/models.py
@@ -178,7 +178,7 @@ class ShapeManager(models.GeoManager):
 
 class ShapefileGroup(models.Model):
     name = models.CharField(max_length=50)
-    display_name = models.CharField(max_length=50)
+    display_name = models.CharField(max_length=50, default="")
     order_of_appearance = models.IntegerField(
         default=0,
         help_text="The order, from left to right, in which you would like this group to appear, when applicable."
@@ -547,7 +547,7 @@ class SnuggetType(models.Model):
 
 class SnuggetSection(models.Model):
     name = models.CharField(max_length=50)
-    display_name = models.CharField(max_length=50, help_text="The name to show for this section", blank=True)
+    display_name = models.CharField(max_length=50, help_text="The name to show for this section", default="")
     order_of_appearance = models.IntegerField(
         default=0,
         help_text="The order in which you'd like this to appear in the tab. 0 is at the top."
@@ -558,7 +558,7 @@ class SnuggetSection(models.Model):
 
 class SnuggetSubSection(models.Model):
     name = models.CharField(max_length=50)
-    display_name = models.CharField(max_length=50, help_text="The name to show for this section", blank=True)
+    display_name = models.CharField(max_length=50, help_text="The name to show for this section", default="")
     order_of_appearance = models.IntegerField(
         default=0,
         help_text="The order in which you'd like this to appear in the section. 0 is at the top. These can be in different sections or mutually exclusive, hence the non-unique values."

--- a/disasterinfosite/models.py
+++ b/disasterinfosite/models.py
@@ -558,7 +558,7 @@ class SnuggetSection(models.Model):
 
 class SnuggetSubSection(models.Model):
     name = models.CharField(max_length=50)
-    display_name = models.CharField(max_length=50, default="The name to show for this section", blank=True)
+    display_name = models.CharField(max_length=50, help_text="The name to show for this section", blank=True)
     order_of_appearance = models.IntegerField(
         default=0,
         help_text="The order in which you'd like this to appear in the section. 0 is at the top. These can be in different sections or mutually exclusive, hence the non-unique values."

--- a/disasterinfosite/models.py
+++ b/disasterinfosite/models.py
@@ -6,6 +6,8 @@ from embed_video.fields import EmbedVideoField
 from model_utils.managers import InheritanceManager
 from solo.models import SingletonModel
 from django.core.files.storage import FileSystemStorage
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
 
 SNUG_TEXT = 0
 SNUG_AUDIO = 1
@@ -545,6 +547,7 @@ class SnuggetType(models.Model):
 
 class SnuggetSection(models.Model):
     name = models.CharField(max_length=50)
+    display_name = models.CharField(max_length=50, help_text="The name to show for this section", blank=True)
     order_of_appearance = models.IntegerField(
         default=0,
         help_text="The order in which you'd like this to appear in the tab. 0 is at the top."
@@ -553,9 +556,9 @@ class SnuggetSection(models.Model):
     def __str__(self):
         return self.name
 
-
 class SnuggetSubSection(models.Model):
     name = models.CharField(max_length=50)
+    display_name = models.CharField(max_length=50, default="The name to show for this section", blank=True)
     order_of_appearance = models.IntegerField(
         default=0,
         help_text="The order in which you'd like this to appear in the section. 0 is at the top. These can be in different sections or mutually exclusive, hence the non-unique values."
@@ -563,6 +566,13 @@ class SnuggetSubSection(models.Model):
 
     def __str__(self):
         return self.name
+
+@receiver(pre_save, sender=SnuggetSection)
+@receiver(pre_save, sender=SnuggetSection)
+@receiver(pre_save, sender=ShapefileGroup)
+def default_display_name(sender, instance, *args, **kwargs):
+    if not instance.display_name:
+        instance.display_name = instance.name
 
 
 class Snugget(models.Model):

--- a/disasterinfosite/templates/found_content.html
+++ b/disasterinfosite/templates/found_content.html
@@ -42,17 +42,16 @@
           {% for section, sub_sections in hazard.sections.items %}
             <div class="snugget-text">
               <div class="section-icon section-icon--dynamic section-icon--{{ section }}">
-                <h2 class="caps section-title">{{ section }}</h2>
+                <h2 class="caps section-title">{{ section.display_name }}</h2>
               </div>
               <div class="section-content">
                 {% for sub_section, snuggets in sub_sections.items %}
-                  <h3>{{ sub_section }}</h3>
+                  <h3>{{ sub_section.display_name }}</h3>
                   {% for snugget in snuggets %}
                     {% show_snugget snugget %}
                   {% endfor %}
                 {% endfor %}
-                {% trans "In Recent History" as recent_history %}
-                {% if section.name == recent_history and hazard.photos %}
+                {% if section.name == "In Recent History" and hazard.photos %}
                   <h3>{% trans "Historical Images" %}</h3>
                   <div class="past-photos">
                     {% for photo in hazard.photos %}

--- a/disasterinfosite/translation.py
+++ b/disasterinfosite/translation.py
@@ -1,5 +1,5 @@
 from modeltranslation.translator import register, translator, TranslationOptions
-from .models import SiteSettings, Location, SupplyKit, ImportantLink, ShapefileGroup, PastEventsPhoto, DataOverviewImage
+from .models import SiteSettings, Location, SupplyKit, ImportantLink, ShapefileGroup, PastEventsPhoto, DataOverviewImage, TextSnugget, SnuggetSection, SnuggetSubSection
 
 @register(SiteSettings)
 class SiteSettingsTranslationOptions(TranslationOptions):
@@ -28,3 +28,15 @@ class PastEventsPhotoTranslationOptions(TranslationOptions):
 @register(DataOverviewImage)
 class DataOverviewImageTranslationOptions(TranslationOptions):
   fields = ('link_text',)
+
+@register(TextSnugget)
+class TextSnuggetTranslationOptions(TranslationOptions):
+  fields = ('content',)
+
+@register(SnuggetSection)
+class SunggetSectionTranslationOptions(TranslationOptions):
+  fields = ('display_name',)
+
+@register(SnuggetSubSection)
+class SunggetSubSectionTranslationOptions(TranslationOptions):
+  fields = ('display_name',)

--- a/snugget_load.py
+++ b/snugget_load.py
@@ -139,7 +139,7 @@ def getSectionID(appName, sectionName, cur, subsection=False):
   if sectionID is not None:
     return sectionID
   else: # if no sectionID was found then we need to create the section
-    cur.execute("INSERT INTO " + tableName + "(name, order_of_appearance) VALUES(%s, %s);", (sectionName, 0))
+    cur.execute("INSERT INTO " + tableName + "(name, order_of_appearance, display_name) VALUES(%s, %s, %s);", (sectionName, 0, sectionName))
     cur.execute("SELECT id FROM " + tableName + " WHERE name = %s;", [sectionName])
     sectionID = cur.fetchone()[0]
     return sectionID

--- a/snugget_load.py
+++ b/snugget_load.py
@@ -108,8 +108,8 @@ def addTextSnugget(appName, row, sectionID, subsectionID, filterColumn, filterID
   )
   snuggetID = getSnuggetID(appName, sectionID, subsectionID, filterColumn, filterID, cur);
   cur.execute(
-    'INSERT INTO ' + appName + '_textsnugget (snugget_ptr_id, content, image, percentage) VALUES (%s, %s, %s, %s);',
-    (snuggetID, row["text"], row["image"], row["intensity"])
+    'INSERT INTO ' + appName + '_textsnugget (snugget_ptr_id, content, content_en, image, percentage) VALUES (%s, %s, %s, %s, %s);',
+    (snuggetID, row["text"], row["text"], row["image"], row["intensity"])
   )
   # For extra credit, set the group's display_name to the heading value.
 

--- a/snugget_load.py
+++ b/snugget_load.py
@@ -107,6 +107,7 @@ def addTextSnugget(appName, row, sectionID, subsectionID, filterColumn, filterID
     (str(sectionID), str(subsectionID), str(groupID), str(filterID))
   )
   snuggetID = getSnuggetID(appName, sectionID, subsectionID, filterColumn, filterID, cur);
+  # TODO: modify this to dynamically read in localized text columns and put them in localized content columns
   cur.execute(
     'INSERT INTO ' + appName + '_textsnugget (snugget_ptr_id, content, content_en, image, percentage) VALUES (%s, %s, %s, %s, %s);',
     (snuggetID, row["text"], row["text"], row["image"], row["intensity"])


### PR DESCRIPTION
I decided to create the notion of a display name for snugget sections and subsections, similar to how the shapefile groups work.

This means that those are editable in Django Admin, and we don't have to translate snugget section and subsection names in the snuggets spreadsheet.