### PR TITLE
Mark added strings for translation and add a results title

### DIFF
--- a/disasterinfosite/static/css/app.css
+++ b/disasterinfosite/static/css/app.css
@@ -313,6 +313,11 @@ DISASTER TABS
   padding-top: 20px;
 }
 
+.disaster-container__title {
+  margin-bottom: 20px;
+  text-align: center;
+}
+
 .tabs .tab-title {
   font-size: 16px;
   font-weight: bold;

--- a/disasterinfosite/templates/found_content.html
+++ b/disasterinfosite/templates/found_content.html
@@ -22,6 +22,9 @@
 
 {% block main-content %}
   <div class="row disaster-container" role="main">
+    <h2 class="caps disaster-container__title">
+      {% trans Results for this location %}
+    </h2>
     <div class="small-12 column">
       <ul class="tabs disaster-tabs" data-tab role="group">
         {% for group, hazard in data.items %}

--- a/disasterinfosite/templates/index.html
+++ b/disasterinfosite/templates/index.html
@@ -130,7 +130,7 @@
 {% include "geek_box.html" %}
 
 <div class="loading hide">
-  <h1 class="loading-text caps">Getting results for your location...</h1>
+  <h1 class="loading-text caps">{% trans "Getting results for your location..." %}</h1>
   <img class="loading-spinner" src="{% static 'img/thinking.gif' %}">
 </div>
 


### PR DESCRIPTION
I chose not to put the location in the results title a la "Results for 42.12312312, -122.23423423" because, well, it looks like *that* a lot of the time, and the location is already up in the search box.

Hopefully this clarifies things.

small:
![image](https://user-images.githubusercontent.com/547883/27712067-301e78be-5cda-11e7-87fd-928cfc21d419.png)

medium:
![image](https://user-images.githubusercontent.com/547883/27712073-35b8cba8-5cda-11e7-95aa-e9fed30d4457.png)

large:
![image](https://user-images.githubusercontent.com/547883/27712076-3ad67554-5cda-11e7-9e8f-7cd64fc2a29e.png)
