### PR TITLE
Fix 'find me' on mobile, make map click show 'loading' message

### DIFF
--- a/disasterinfosite/static/js/app.js
+++ b/disasterinfosite/static/js/app.js
@@ -53,8 +53,11 @@ function enableForm() {
 }
 
 function submitLocation(lat,lng, location_query_text) {
-  // reload the page with the lat,lng
-  document.location =  encodeURI(document.location.pathname + "?lat=" + lat + "&lng=" + lng + "&loc=" + location_query_text);
+  var queryString = "?lat=" + lat + "&lng=" + lng;
+  if(location_query_text && location_query_text.length) {
+    queryString = queryString  + "&loc=" + location_query_text;
+  }
+  document.location =  encodeURI(document.location.pathname + queryString);
 }
 
 function submitLocationQuery() {
@@ -248,7 +251,7 @@ $( document ).ready(function() {
       var lat = position.coords.latitude;
       var lng = position.coords.longitude;
       // success! onwards to view the content
-      submitLocation(lat, lng, "");
+      submitLocation(lat, lng);
     };
     var geoError = function(error) {
       console.log('Error finding your location: ' + error.message);

--- a/disasterinfosite/static/js/app.js
+++ b/disasterinfosite/static/js/app.js
@@ -232,6 +232,7 @@ $( document ).ready(function() {
   // Make a click on the map submit the location
   map.on('click', function(e) {
     $locationInput.val("");  // clear query text
+    disableForm();
     submitLocation(e.latlng.lat, e.latlng.lng, "");
   });
 

--- a/disasterinfosite/templates/index.html
+++ b/disasterinfosite/templates/index.html
@@ -64,11 +64,8 @@
               {% trans "Find Me" as find_me %}
               <div class="row hidden-for-medium-up">
                 <div class="small-6 small-centered columns form-icon-button">
-                   <a class="auto-location-submit button radius caps">{{ find_me }}</a>
+                   <button class="auto-location-submit button radius caps">{{ find_me }}</button>
                 </div>
-                <div class="small-12 hide-for-small medium-3 columns form-icon-button">
-                  <a class="auto-location-submit button radius caps">{{ find_me }}</a>
-               </div>
               </div>
            </div>
         </div>


### PR DESCRIPTION
'Find Me' was going back to the home page, because it was a link instead of a button for some reason.

The map click wasn't calling disableForm(), which shows the loading UI in addition to disabling the form.
