### PR TITLE
Reference variables from modeltranslation classes correctly inside blocktrans

### DIFF
--- a/disasterinfosite/templates/geek_box.html
+++ b/disasterinfosite/templates/geek_box.html
@@ -5,26 +5,26 @@
       <div class="small-12 medium-6 columns">
         <h3 class="caps">{% trans "How does it work?" %}</h3>
         <p>
-            {% blocktrans %}
-                {{ settings.site_title }} is designed to help educate and prepare people for disasters that occur in their area. Disasters don’t strike locations equally so we found it important to give location specific information in order to properly prepare. {{ settings.site_title }} organizes current information and packages it in a way that makes it accessible for any {{ location.area_name }} resident.
+            {% blocktrans with title=settings.site_title area_name=location.area_name %}
+                {{ title }} is designed to help educate and prepare people for disasters that occur in their area. Disasters don’t strike locations equally so we found it important to give location specific information in order to properly prepare. {{ title }} organizes current information and packages it in a way that makes it accessible for any {{ area_name }} resident.
             {% endblocktrans %}
         </p>
         <p>
-            {% blocktrans %}
-                This site uses the most up-to-date hazard risk data available for {{ location.area_name }}. The user of this site is responsible for verifying any particular information with the original data sources. Although these data represent the best current assessment of hazards, they are not predictive of future events. The descriptions of risk and how to prepare for those risks are based on best information from the American Red Cross and the Federal Emergency Management Agency.
+            {% blocktrans with area_name=location.area_name %}
+                This site uses the most up-to-date hazard risk data available for {{ area_name }}. The user of this site is responsible for verifying any particular information with the original data sources. Although these data represent the best current assessment of hazards, they are not predictive of future events. The descriptions of risk and how to prepare for those risks are based on best information from the American Red Cross and the Federal Emergency Management Agency.
             {% endblocktrans %}
         </p>
         {% if settings.data_download %}
             <p>
-                {% blocktrans %}
-                    Data used for {{ settings.site_title }} is available for download <a href="{{settings.data_download}}" target="_blank">here</a>.
+                {% blocktrans with title=settings.site_title download=settings.data_download%}
+                    Data used for {{ title }} is available for download <a href="{{ download }}" target="_blank">here</a>.
                 {% endblocktrans %}
             </p>
         {% endif %}
         {% if settings.contact_email %}
             <p>
-                {% blocktrans %}
-                    Have questions? <a href="mailto:{{ settings.contact_email }}">Email the creators</a> for more information.
+                {% blocktrans with email=settings.contact_email %}
+                    Have questions? <a href="mailto:{{ email }}">Email the creators</a> for more information.
                 {% endblocktrans %}
             </p>
         {% endif %}
@@ -33,7 +33,7 @@
         <div class="small-12 medium-6 columns">
             <h3 class="caps">{% trans "Quick Data Overview" %}</h3>
             <p>
-                {% blocktrans %}Take a look at some overviews of the data we used for {{ location.area_name }}:{% endblocktrans %}
+                {% blocktrans with area_name=location.area_name %}Take a look at some overviews of the data we used for {{ area_name }}:{% endblocktrans %}
             </p>
             <ul>
                 {% for item in quick_data_overview %}

--- a/disasterinfosite/templates/index.html
+++ b/disasterinfosite/templates/index.html
@@ -84,8 +84,8 @@
         <h2 class="caps">{% trans "What are my risks?" %}</h2>
         <h3 class>{% trans "What to Expect" %}</h3>
         <p>
-          {% blocktrans %}
-            {{ settings.site_title }} gives you an idea of which natural disasters you might experience in the future based on a location in {{ location.area_name }}.
+          {% blocktrans with title=settings.site_title area_name=location.area_name%}
+            {{ title }} gives you an idea of which natural disasters you might experience in the future based on a location in {{ area_name }}.
           {% endblocktrans %}
         </p>
 
@@ -96,8 +96,8 @@
 
         <h3>{% trans "In Recent History" %}</h3>
         <p>
-          {% blocktrans %}
-            Find out which disasters have struck {{ location.area_name }} in the past, what impact they had, and where they happened.
+          {% blocktrans with area_name=location.area_name%}
+            Find out which disasters have struck {{ area_name }} in the past, what impact they had, and where they happened.
           {% endblocktrans %}
         </p>
       </div>

--- a/disasterinfosite/templates/no_content_found.html
+++ b/disasterinfosite/templates/no_content_found.html
@@ -27,7 +27,7 @@
           <h2 class="caps">{% trans "No information available." %}</h2>
           <div>
             <p>
-              {% blocktrans %}
+              {% blocktrans with area_name=location.area_name %}
                 It looks like your location is outside of {{ location.area_name }}.
               {% endblocktrans %}
             </p>


### PR DESCRIPTION
This is a fix for https://trello.com/c/FHbHerUQ/48-how-does-it-work-section-cant-do-double-escaping-in-blocktrans-so-remove-template-tags-from-blocktrans-or-escape-them-properly

The problem is that in order for blocktrans to play nicely with modeltranslation, you have to reference the modeltranslation variables like `{% blocktrans with title=settings.site_title %}`