### PR TITLE
Switch to a typeface with better Cyrillic support

### DIFF
--- a/disasterinfosite/static/css/app.css
+++ b/disasterinfosite/static/css/app.css
@@ -10,7 +10,7 @@ html {
 body {
   height:auto !important;
   width:auto !important;
-  font-family: 'Arvo', serif;
+  font-family: 'Roboto Slab', serif;
   color: #081f2c;
 }
 

--- a/disasterinfosite/templates/index.html
+++ b/disasterinfosite/templates/index.html
@@ -17,7 +17,7 @@
 
   <!-- Load fonts -->
   <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css?family=Arvo" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto+Slab" rel="stylesheet">
 
   <script type="text/javascript">
     var mapBounds = {{ data_bounds | js }};


### PR DESCRIPTION
Before - we were using a typeface that doesn't support Cyrillic, so it was falling back to Times New Roman I think, which is so 1992:
![image](https://user-images.githubusercontent.com/547883/30232306-259fd304-94a4-11e7-8319-b0f562c74f0c.png)

After:
![image](https://user-images.githubusercontent.com/547883/30232318-35c296ea-94a4-11e7-99ca-921b57ec333a.png)

