### PR TITLE
Fix MEDIA_URL path for i18n

### DIFF
--- a/disasterinfosite/settings.py
+++ b/disasterinfosite/settings.py
@@ -173,4 +173,4 @@ if DEBUG:
 else:
     MEDIA_ROOT = os.path.join(BASE_DIR, 'staticfiles', 'img')
 
-MEDIA_URL = 'static/img/'
+MEDIA_URL = '/static/img/'


### PR DESCRIPTION
I'll fix this up in the `seattle-ready-settings` branch as well so that it works in a subdirectory.