### PR TITLE
Prune no longer used Python module dependency

### DIFF
--- a/snugget_load.py
+++ b/snugget_load.py
@@ -1,5 +1,4 @@
 import os
-import csv
 
 import openpyxl # library to read .xlsx format
 import psycopg2


### PR DESCRIPTION
I happened to look at this script while working on something else, and realised that it still imported the Python CSV module even though I fully switched it to using Excel files some time ago. This PR simply fixes that.