### PR TITLE
Use RTL friendly directives for the autocomplete close button

### DIFF
--- a/disasterinfosite/static/style/_header.scss
+++ b/disasterinfosite/static/style/_header.scss
@@ -164,6 +164,11 @@ header {
   z-index: $z-index-high;
 }
 
+.geoapify-close-button {
+  inset-inline-end: 5px;
+  right: unset;
+}
+
 #location-submit {
   background-color: $light-accent;
   border: 1px solid $light-accent;


### PR DESCRIPTION
Otherwise, the close button appears over the input text in Arabic, like so:

![image](https://github.com/hazard-ready/seattle-ready/assets/547883/973d7f8e-0c60-4ea9-960a-00ecb23c4944)


